### PR TITLE
Fix FastAPI startup with Pydantic v2

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     adomd_connection: str = ""

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -4,7 +4,7 @@ from ..config import settings
 
 try:
     from pyadomd import Pyadomd
-except ImportError:  # fallback if pyadomd not installed
+except Exception:  # fallback if pyadomd is unavailable or fails to load
     Pyadomd = None
 
 router = APIRouter(prefix="/query", tags=["query"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
 pydantic
+pydantic-settings
 pyadomd
 python-dotenv


### PR DESCRIPTION
## Summary
- update settings import for pydantic v2
- catch broader exception when loading pyadomd
- add `pydantic-settings` to requirements

## Testing
- `python -m pip install -r backend/requirements.txt`
- `python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 --log-level info` *(started successfully then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6882a05de690832280a706ca77821fa4