### PR TITLE
Add cube metadata endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
 
-from .routers import query, reports
+from .routers import query, reports, fields
 
 app = FastAPI(title="Cube Visual")
 
 app.include_router(query.router)
 app.include_router(reports.router)
+app.include_router(fields.router)

--- a/backend/app/routers/fields.py
+++ b/backend/app/routers/fields.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+from ..config import settings
+
+try:
+    from pyadomd import Pyadomd
+except Exception:
+    Pyadomd = None
+
+router = APIRouter(prefix="/fields", tags=["fields"])
+
+@router.get("")
+def list_fields():
+    if Pyadomd is None:
+        # Fallback with empty lists when pyadomd is not available
+        return {"dimensions": [], "measures": []}
+
+    conn_str = settings.adomd_connection
+    if not conn_str:
+        raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
+
+    try:
+        with Pyadomd(conn_str) as conn:
+            # List dimensions
+            with conn.cursor().execute("SELECT DIMENSION_NAME FROM $system.MDSCHEMA_DIMENSIONS") as cur:
+                dimensions = [row[0] for row in cur.fetchall()]
+            # List measures
+            with conn.cursor().execute("SELECT MEASURE_NAME FROM $system.MDSCHEMA_MEASURES") as cur:
+                measures = [row[0] for row in cur.fetchall()]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"dimensions": dimensions, "measures": measures}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,14 +11,25 @@ interface QueryResult {
   data: Record<string, any>[];
 }
 
+interface CubeFields {
+  dimensions: string[];
+  measures: string[];
+}
+
 const App: React.FC = () => {
   const [mdx, setMdx] = useState('');
   const [result, setResult] = useState<QueryResult | null>(null);
   const [reports, setReports] = useState<Report[]>([]);
+  const [fields, setFields] = useState<CubeFields | null>(null);
 
   const fetchReports = async () => {
     const { data } = await axios.get<Report[]>('/reports');
     setReports(data);
+  };
+
+  const fetchFields = async () => {
+    const { data } = await axios.get<CubeFields>('/fields');
+    setFields(data);
   };
 
   const runQuery = async () => {
@@ -34,11 +45,35 @@ const App: React.FC = () => {
 
   useEffect(() => {
     fetchReports();
+    fetchFields();
   }, []);
 
   return (
     <div>
       <h1>Cube Visual</h1>
+      {fields && (
+        <div>
+          <h2>Available Fields</h2>
+          <div style={{ display: 'flex', gap: '2rem' }}>
+            <div>
+              <h3>Dimensions</h3>
+              <ul>
+                {fields.dimensions.map(d => (
+                  <li key={d}>{d}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3>Measures</h3>
+              <ul>
+                {fields.measures.map(m => (
+                  <li key={m}>{m}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
       <textarea value={mdx} onChange={e => setMdx(e.target.value)} rows={4} cols={80} />
       <div>
         <button onClick={runQuery}>Run Query</button>


### PR DESCRIPTION
## Summary
- add `/fields` endpoint to list cube dimensions and measures
- display cube fields in the frontend

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_6882a214904483228bd755e8ce727904