### PR TITLE
Fix fields endpoint proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ docker compose up --build
 The backend will be available at `http://localhost:8000`. Endpoints:
 
 - `POST /query` – run an MDX query ({"mdx": "..."})
+- `GET /fields` – list available cube dimensions and measures
 - `GET /reports` – list saved reports
 - `POST /reports` – save a new report ({"name": "Report", "mdx": "..."})
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   server: {
     proxy: {
       '/query': 'http://localhost:8000',
-      '/reports': 'http://localhost:8000'
+      '/reports': 'http://localhost:8000',
+      '/fields': 'http://localhost:8000'
     }
   }
 });


### PR DESCRIPTION
## Summary
- update Vite config so `/fields` is proxied to the backend
- document `/fields` endpoint in README

## Testing
- `npm install`
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882afd6fc988322b5e997f8baa5c227