### PR TITLE
Add cube connection health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The backend will be available at `http://localhost:8000`. Endpoints:
 
 - `POST /query` – run an MDX query ({"mdx": "..."})
 - `GET /fields` – list available cube dimensions and measures
+- `GET /health` – verify cube connection
 - `GET /reports` – list saved reports
 - `POST /reports` – save a new report ({"name": "Report", "mdx": "..."})
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
-from .routers import query, reports, fields
+from .routers import query, reports, fields, health
 
 app = FastAPI(title="Cube Visual")
 
 app.include_router(query.router)
 app.include_router(reports.router)
 app.include_router(fields.router)
+app.include_router(health.router)

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+from ..config import settings
+
+try:
+    from pyadomd import Pyadomd
+except Exception:
+    Pyadomd = None
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get("")
+def health_check():
+    """Simple health check ensuring connection to the cube works."""
+    if Pyadomd is None:
+        raise HTTPException(status_code=500, detail="pyadomd not installed")
+    conn_str = settings.adomd_connection
+    if not conn_str:
+        raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
+    try:
+        with Pyadomd(conn_str) as conn:
+            with conn.cursor().execute(
+                "SELECT TABLE_CATALOG FROM $system.dbschema_catalogs"
+            ) as cur:
+                cur.fetchone()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {e}")
+    return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add `/health` endpoint to verify connection to the cube
- wire new router in `main.py`
- document the new endpoint in README

## Testing
- `python -m py_compile backend/app/routers/health.py backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6882b17cc1c08322a5cbe507bb7ea874