### PR TITLE
Switch backend to pyadomd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This project provides a simple web interface to query an OLAP cube and visualize
 results in a spreadsheet‑like interface. The backend is built with **FastAPI**
-and uses **pyodbc** and **pymdx** to query the cube. The frontend is built with
+and uses **pyadomd** to query the cube. The frontend is built with
 **React** and **TypeScript**.
 
 ## Requirements
 
 - Python 3.10+
 - Node.js 18+
-- Access to an OLAP cube via ODBC. Create a `.env` file inside `backend` with the variable `ADOMD_CONNECTION` set to your connection string (see `backend/.env.example`).
+- Access to an OLAP cube. Create a `.env` file inside `backend` with the variable `ADOMD_CONNECTION` set to your connection string (see `backend/.env.example`).
 
 ## Running the backend
 

--- a/backend/app/routers/fields.py
+++ b/backend/app/routers/fields.py
@@ -2,16 +2,16 @@ from fastapi import APIRouter, HTTPException
 from ..config import settings
 
 try:
-    import pyodbc
+    from pyadomd import Pyadomd
 except Exception:
-    pyodbc = None
+    Pyadomd = None
 
 router = APIRouter(prefix="/fields", tags=["fields"])
 
 @router.get("")
 def list_fields():
-    if pyodbc is None:
-        # Fallback with empty lists when pyodbc is not available
+    if Pyadomd is None:
+        # Fallback with empty lists when pyadomd is not available
         return {"dimensions": [], "measures": []}
 
     conn_str = settings.adomd_connection
@@ -19,7 +19,7 @@ def list_fields():
         raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
 
     try:
-        with pyodbc.connect(conn_str) as conn:
+        with Pyadomd(conn_str) as conn:
             cur = conn.cursor()
             # List dimensions
             cur.execute("SELECT DIMENSION_NAME FROM $system.MDSCHEMA_DIMENSIONS")

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, HTTPException
 from ..config import settings
 
 try:
-    import pyodbc
+    from pyadomd import Pyadomd
 except Exception:
-    pyodbc = None
+    Pyadomd = None
 
 router = APIRouter(prefix="/health", tags=["health"])
 
@@ -12,13 +12,13 @@ router = APIRouter(prefix="/health", tags=["health"])
 @router.get("")
 def health_check():
     """Simple health check ensuring connection to the cube works."""
-    if pyodbc is None:
-        raise HTTPException(status_code=500, detail="pyodbc not installed")
+    if Pyadomd is None:
+        raise HTTPException(status_code=500, detail="pyadomd not installed")
     conn_str = settings.adomd_connection
     if not conn_str:
         raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
     try:
-        with pyodbc.connect(conn_str) as conn:
+        with Pyadomd(conn_str) as conn:
             cur = conn.cursor()
             cur.execute("SELECT TABLE_CATALOG FROM $system.dbschema_catalogs")
             cur.fetchone()

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -3,20 +3,20 @@ from ..schemas import QueryRequest, QueryResponse
 from ..config import settings
 
 try:
-    import pyodbc
-except Exception:  # fallback if pyodbc is unavailable or fails to load
-    pyodbc = None
+    from pyadomd import Pyadomd
+except Exception:  # fallback if pyadomd is unavailable or fails to load
+    Pyadomd = None
 
 router = APIRouter(prefix="/query", tags=["query"])
 
 @router.post("", response_model=QueryResponse)
 def run_query(req: QueryRequest):
-    if pyodbc is None:
-        raise HTTPException(status_code=500, detail="pyodbc not installed")
+    if Pyadomd is None:
+        raise HTTPException(status_code=500, detail="pyadomd not installed")
     conn_str = settings.adomd_connection
     if not conn_str:
         raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
-    with pyodbc.connect(conn_str) as conn:
+    with Pyadomd(conn_str) as conn:
         cur = conn.cursor()
         cur.execute(req.mdx)
         columns = [c[0] for c in cur.description]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 pydantic
 pydantic-settings
-pyodbc
+pyadomd
 python-dotenv


### PR DESCRIPTION
## Summary
- replace `pyodbc` with `pyadomd` for querying the cube
- update API routers to use `Pyadomd`
- adjust README with new dependency
- update backend requirements

## Testing
- `python -m py_compile backend/app/routers/query.py backend/app/routers/fields.py backend/app/routers/health.py`


------
https://chatgpt.com/codex/tasks/task_e_6883445b1c408322bdfaa33901eda647