### PR TITLE
Add XMLA support for cube

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 This project provides a simple web interface to query an OLAP cube and visualize
 results in a spreadsheet‑like interface. The backend is built with **FastAPI**
-and uses **pyadomd** to query the cube. The frontend is built with
+and uses the **xmla** library to query the cube. The frontend is built with
 **React** and **TypeScript**.
 
 ## Requirements
 
 - Python 3.10+
 - Node.js 18+
-- Access to an OLAP cube. Create a `.env` file inside `backend` with the variable `ADOMD_CONNECTION` set to your connection string (see `backend/.env.example`).
+- Access to an OLAP cube. Create a `.env` file inside `backend` with connection
+  details for your cube (see `backend/.env.example`). The main settings are
+  `XMLA_URL`, `XMLA_USERNAME`, `XMLA_PASSWORD` and optionally `XMLA_CATALOG`.
 
 ## Running the backend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,5 @@
-ADOMD_CONNECTION=Your_OLAP_connection_string
+# Connection details for XMLA access
+XMLA_URL=http://your-server/olap/msmdpump.dll
+XMLA_USERNAME=your_username
+XMLA_PASSWORD=your_password
+XMLA_CATALOG=your_catalog

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,10 @@
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
-    adomd_connection: str = ""
+    xmla_url: str = ""
+    xmla_username: str = ""
+    xmla_password: str = ""
+    xmla_catalog: str = ""
 
     class Config:
         env_file = ".env"

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -3,23 +3,50 @@ from ..schemas import QueryRequest, QueryResponse
 from ..config import settings
 
 try:
-    from pyadomd import Pyadomd
-except Exception:  # fallback if pyadomd is unavailable or fails to load
-    Pyadomd = None
+    from olap.xmla.xmla import XMLAProvider
+except Exception:
+    XMLAProvider = None
 
 router = APIRouter(prefix="/query", tags=["query"])
 
 @router.post("", response_model=QueryResponse)
 def run_query(req: QueryRequest):
-    if Pyadomd is None:
-        raise HTTPException(status_code=500, detail="pyadomd not installed")
-    conn_str = settings.adomd_connection
-    if not conn_str:
-        raise HTTPException(status_code=500, detail="ADOMD_CONNECTION not configured")
-    with Pyadomd(conn_str) as conn:
-        cur = conn.cursor()
-        cur.execute(req.mdx)
-        columns = [c[0] for c in cur.description]
-        data = [dict(zip(columns, row)) for row in cur.fetchall()]
-        cur.close()
-    return QueryResponse(columns=columns, data=data)
+    if XMLAProvider is None:
+        raise HTTPException(status_code=500, detail="xmla library not installed")
+
+    if not settings.xmla_url:
+        raise HTTPException(status_code=500, detail="XMLA_URL not configured")
+
+    try:
+        provider = XMLAProvider()
+        conn = provider.connect(
+            location=settings.xmla_url,
+            username=settings.xmla_username or None,
+            password=settings.xmla_password or None,
+        )
+        result = conn.Execute(req.mdx, Catalog=settings.xmla_catalog or None)
+        columns = [
+            m.CAPTION if hasattr(m, "CAPTION") else m.getUniqueName()
+            for m in result.getAxisTuple(0)
+        ]
+        rows = result.getAxisTuple(1)
+        cells = result.getSlice(properties="Value")
+        data = []
+        if rows:
+            for r_idx, row in enumerate(rows):
+                row_caption = row.CAPTION if hasattr(row, "CAPTION") else row.getUniqueName()
+                row_values = cells[r_idx]
+                row_dict = {"Row": row_caption}
+                for c_idx, col in enumerate(columns):
+                    row_dict[col] = row_values[c_idx]
+                data.append(row_dict)
+            columns = ["Row"] + columns
+        else:
+            row_dict = {}
+            for c_idx, col in enumerate(columns):
+                row_dict[col] = cells[c_idx]
+            data.append(row_dict)
+
+        return QueryResponse(columns=columns, data=data)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 pydantic
 pydantic-settings
-pyadomd
 python-dotenv
+xmla @ git+https://github.com/may-day/olap.git#subdirectory=xmla

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - ADOMD_CONNECTION=${ADOMD_CONNECTION}
+      - XMLA_URL=${XMLA_URL}
+      - XMLA_USERNAME=${XMLA_USERNAME}
+      - XMLA_PASSWORD=${XMLA_PASSWORD}
+      - XMLA_CATALOG=${XMLA_CATALOG}


### PR DESCRIPTION
## Summary
- switch backend from pyadomd to xmla
- update env example with XMLA settings
- adjust health, fields, and query routers for xmla
- update requirements and docker-compose
- document XMLA variables in README

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_68835dea24408322ae48529266fbdbc5