### PR TITLE
Add SSAS integration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ docker compose up --build
 ```
 
 The backend will be available at `http://localhost:8000`.
+
+## Running tests
+
+Unit tests are located in the `tests` directory and use **pytest**. After
+installing the backend dependencies simply run:
+
+```bash
+pip install -r backend/requirements.txt
+pytest
+```
+
+The tests mock the cube connection, so they run without requiring access to an
+actual OLAP server.

--- a/backend/app/ssas.py
+++ b/backend/app/ssas.py
@@ -1,0 +1,30 @@
+import typing
+
+try:
+    import clr  # type: ignore
+    from System.Reflection import Assembly
+except Exception as e:  # pragma: no cover - import-time errors
+    clr = None
+    Assembly = None
+    _import_error = e
+else:
+    _import_error = None
+
+
+def process_cube(server_name: str, db_name: str) -> None:
+    """Process an SSAS cube using .NET APIs via pythonnet."""
+    if clr is None:
+        raise ImportError(f"pythonnet not available: {_import_error}")
+
+    try:
+        Assembly.LoadWithPartialName("AnalysisServices.DLL")
+    except Exception as e:
+        raise RuntimeError(f"Failed to load AnalysisServices.DLL: {e}")
+
+    from Microsoft.AnalysisServices import Server, ProcessType  # type: ignore
+
+    server = Server()
+    server.Connect(server_name)
+
+    db = server.Databases[db_name]
+    db.Process(ProcessType.ProcessFull)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,7 @@ pydantic
 pydantic-settings
 python-dotenv
 xmla @ git+https://github.com/may-day/olap.git#subdirectory=xmla
+
+pythonnet
+pytest
+httpx

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+from backend.app.routers import health
+
+
+class DummyConn:
+    def getDBSchemaCatalogs(self):
+        return []
+
+
+class DummyProvider:
+    def connect(self, location, username=None, password=None):
+        return DummyConn()
+
+
+def test_health_success(monkeypatch):
+    monkeypatch.setattr(health, "XMLAProvider", DummyProvider)
+    monkeypatch.setattr(health.settings, "xmla_url", "localhost")
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_health_no_provider(monkeypatch):
+    monkeypatch.setattr(health, "XMLAProvider", None)
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "xmla library not installed"

--- a/tests/test_ssas.py
+++ b/tests/test_ssas.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+import types
+import sys
+import pytest
+
+import backend.app.ssas as ssas
+
+
+def test_process_cube_missing_pythonnet(monkeypatch):
+    monkeypatch.setattr(ssas, "clr", None)
+    with pytest.raises(ImportError):
+        ssas.process_cube("server", "db")
+
+
+def test_process_cube_calls_net(monkeypatch):
+    fake_server = MagicMock()
+    fake_db = fake_server.Databases.__getitem__.return_value
+
+    monkeypatch.setattr(ssas, "clr", object())
+    monkeypatch.setattr(ssas, "Assembly", MagicMock(LoadWithPartialName=MagicMock()))
+    monkeypatch.setitem(ssas.__dict__, "_import_error", None)
+
+    mod = types.ModuleType("Microsoft.AnalysisServices")
+    mod.Server = MagicMock(return_value=fake_server)
+    mod.ProcessType = MagicMock(ProcessFull="FULL")
+    sys.modules["Microsoft.AnalysisServices"] = mod
+
+    ssas.process_cube("server", "db")
+
+    fake_server.Connect.assert_called_with("server")
+    fake_db.Process.assert_called_with(mod.ProcessType.ProcessFull)


### PR DESCRIPTION
## Summary
- add SSAS processing helper using pythonnet
- include unit tests for SSAS helper and health endpoint
- document running tests in README
- update backend requirements with pythonnet, pytest, httpx

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883699a71bc8322808b6549e88212de