### PR TITLE
Fix docker build error by installing git

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim
 
+# Install git for dependencies fetched from version control
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- install git in the backend Dockerfile so that pip can fetch dependencies

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68836be65950832286d767de986843b4