### PR TITLE
Switch backend to pyadomd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project provides a simple web interface to query an OLAP cube and visualize
 results in a spreadsheet‑like interface. The backend is built with **FastAPI**
-and uses the **xmla** library to query the cube. The frontend is built with
+and uses **pyadomd** (ADOMD.NET) to query the cube. The frontend is built with
 **React** and **TypeScript**.
 
 ## Requirements
@@ -11,7 +11,7 @@ and uses the **xmla** library to query the cube. The frontend is built with
 - Node.js 18+
 - Access to an OLAP cube. Create a `.env` file inside `backend` with connection
   details for your cube (see `backend/.env.example`). The main settings are
-  `XMLA_URL`, `XMLA_USERNAME`, `XMLA_PASSWORD` and optionally `XMLA_CATALOG`.
+  `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`.
 
 ## Running the backend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,3 @@
-# Connection details for XMLA access
-XMLA_URL=http://your-server/olap/msmdpump.dll
-XMLA_USERNAME=your_username
-XMLA_PASSWORD=your_password
-XMLA_CATALOG=your_catalog
+# Connection details for ADOMD.NET access via pyadomd
+ADOMD_DLL_PATH=C:\\Program Files\\Microsoft.NET\\ADOMD.NET\\110\\Microsoft.AnalysisServices.AdomdClient.dll
+ADOMD_CONN_STR=Provider=MSOLAP;Data Source=server;Initial Catalog=Cube8;Integrated Security=SSPI;

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,6 +6,9 @@ class Settings(BaseSettings):
     xmla_password: str = ""
     xmla_catalog: str = ""
 
+    adomd_dll_path: str = ""
+    adomd_conn_str: str = ""
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -1,52 +1,39 @@
 from fastapi import APIRouter, HTTPException
+import os
 from ..schemas import QueryRequest, QueryResponse
 from ..config import settings
 
 try:
-    from olap.xmla.xmla import XMLAProvider
-except Exception:
-    XMLAProvider = None
+    import clr  # type: ignore
+    from System.Reflection import Assembly  # type: ignore
+    from pyadomd import Pyadomd  # type: ignore
+except Exception:  # pragma: no cover - import errors
+    clr = None
+    Assembly = None
+    Pyadomd = None
 
 router = APIRouter(prefix="/query", tags=["query"])
 
+
 @router.post("", response_model=QueryResponse)
 def run_query(req: QueryRequest):
-    if XMLAProvider is None:
-        raise HTTPException(status_code=500, detail="xmla library not installed")
+    if Pyadomd is None or clr is None:
+        raise HTTPException(status_code=500, detail="pyadomd library not installed")
 
-    if not settings.xmla_url:
-        raise HTTPException(status_code=500, detail="XMLA_URL not configured")
+    if not settings.adomd_conn_str:
+        raise HTTPException(status_code=500, detail="ADOMD_CONN_STR not configured")
 
     try:
-        provider = XMLAProvider()
-        conn = provider.connect(
-            location=settings.xmla_url,
-            username=settings.xmla_username or None,
-            password=settings.xmla_password or None,
-        )
-        result = conn.Execute(req.mdx, Catalog=settings.xmla_catalog or None)
-        columns = [
-            m.CAPTION if hasattr(m, "CAPTION") else m.getUniqueName()
-            for m in result.getAxisTuple(0)
-        ]
-        rows = result.getAxisTuple(1)
-        cells = result.getSlice(properties="Value")
-        data = []
-        if rows:
-            for r_idx, row in enumerate(rows):
-                row_caption = row.CAPTION if hasattr(row, "CAPTION") else row.getUniqueName()
-                row_values = cells[r_idx]
-                row_dict = {"Row": row_caption}
-                for c_idx, col in enumerate(columns):
-                    row_dict[col] = row_values[c_idx]
-                data.append(row_dict)
-            columns = ["Row"] + columns
-        else:
-            row_dict = {}
-            for c_idx, col in enumerate(columns):
-                row_dict[col] = cells[c_idx]
-            data.append(row_dict)
+        if settings.adomd_dll_path:
+            os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
+            Assembly.LoadFrom(settings.adomd_dll_path)
 
+        with Pyadomd(settings.adomd_conn_str) as conn:
+            with conn.cursor() as cur:
+                cur.execute(req.mdx)
+                columns = [d[0] for d in cur.description]
+                rows = cur.fetchall()
+        data = [dict(zip(columns, r)) for r in rows]
         return QueryResponse(columns=columns, data=data)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,5 +6,6 @@ python-dotenv
 xmla @ git+https://github.com/may-day/olap.git#subdirectory=xmla
 
 pythonnet
+pyadomd
 pytest
 httpx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,5 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - XMLA_URL=${XMLA_URL}
-      - XMLA_USERNAME=${XMLA_USERNAME}
-      - XMLA_PASSWORD=${XMLA_PASSWORD}
-      - XMLA_CATALOG=${XMLA_CATALOG}
+      - ADOMD_DLL_PATH=${ADOMD_DLL_PATH}
+      - ADOMD_CONN_STR=${ADOMD_CONN_STR}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,22 +1,48 @@
 from fastapi.testclient import TestClient
-
 from backend.app.main import app
 from backend.app.routers import health
 
 
+class DummyCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql):
+        pass
+
+    def fetchone(self):
+        return ["ok"]
+
+
 class DummyConn:
-    def getDBSchemaCatalogs(self):
-        return []
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def cursor(self):
+        return DummyCursor()
 
 
-class DummyProvider:
-    def connect(self, location, username=None, password=None):
+class DummyPyadomd:
+    def __init__(self, conn_str):
+        self.conn_str = conn_str
+
+    def __enter__(self):
         return DummyConn()
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
 
 
 def test_health_success(monkeypatch):
-    monkeypatch.setattr(health, "XMLAProvider", DummyProvider)
-    monkeypatch.setattr(health.settings, "xmla_url", "localhost")
+    monkeypatch.setattr(health, "Pyadomd", DummyPyadomd)
+    monkeypatch.setattr(health, "clr", object())
+    monkeypatch.setattr(health.settings, "adomd_conn_str", "cs")
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 200
@@ -24,8 +50,8 @@ def test_health_success(monkeypatch):
 
 
 def test_health_no_provider(monkeypatch):
-    monkeypatch.setattr(health, "XMLAProvider", None)
+    monkeypatch.setattr(health, "Pyadomd", None)
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 500
-    assert resp.json()["detail"] == "xmla library not installed"
+    assert resp.json()["detail"] == "pyadomd library not installed"


### PR DESCRIPTION
## Summary
- switch cube access from XMLA to ADOMD.NET via `pyadomd`
- update configuration and docker compose environment variables
- adjust API routers to use the new connection method
- add `pyadomd` to backend requirements
- update example env file and documentation
- update tests for the new backend

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68838ffcf6448322bae43db7a1d6e51a