### PR TITLE
Fix PyADOMD import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ and uses **pyadomd** (ADOMD.NET) to query the cube. The frontend is built with
 
 - Python 3.10+
 - Node.js 18+
+- A .NET runtime. The Docker image installs `dotnet-runtime-8.0` and sets
+  `PYTHONNET_RUNTIME=coreclr`. When running directly on Windows install
+  [.NET 8](https://dotnet.microsoft.com/download) and set the same environment
+  variable so pythonnet loads the CoreCLR runtime.
 - Access to an OLAP cube. Create a `.env` file inside `backend` with connection
   details for your cube (see `backend/.env.example`). The main settings are
   `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.11-slim
 
-# Install git for dependencies fetched from version control
+# Install git (for dependencies fetched from VCS) and the .NET runtime
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
+    && apt-get install -y --no-install-recommends git dotnet-runtime-8.0 \
     && rm -rf /var/lib/apt/lists/*
+
+# Use .NET (CoreCLR) with pythonnet
+ENV PYTHONNET_RUNTIME=coreclr
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install dotnet runtime in the backend image
- set `PYTHONNET_RUNTIME` so pythonnet uses CoreCLR
- document .NET runtime requirement in README
- mention how to set up on Windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68868b64e0b48322a7170ca1d5f0bec4