### PR TITLE
Refactor cube connection setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ and uses **pyadomd** (ADOMD.NET) to query the cube. The frontend is built with
   variable so pythonnet loads the CoreCLR runtime.
 - Access to an OLAP cube. Create a `.env` file inside `backend` with connection
   details for your cube (see `backend/.env.example`). The main settings are
-  `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`.
+  `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`. If `ADOMD_CONN_STR` is not provided the
+  example connection string
+
+  ```python
+  conn_str = (
+      "Provider=MSOLAP;"
+      "Data Source=server;"
+      "Initial Catalog=Cube8;"
+      "Integrated Security=SSPI;"
+  )
+  ```
+
+  will be used.
 
 ## Running the backend
 
@@ -76,3 +88,11 @@ pytest
 
 The tests mock the cube connection, so they run without requiring access to an
 actual OLAP server.
+
+## Example: list cube measures
+
+Use the helper script to print all measures from a cube. Set `CUBE_NAME` and connection variables in `.env` and run:
+
+```bash
+CUBE_NAME=NextGen python -m backend.app.list_measures
+```

--- a/backend/app/connection.py
+++ b/backend/app/connection.py
@@ -1,0 +1,32 @@
+import os
+from .config import settings
+
+try:
+    import clr  # type: ignore
+    from System.Reflection import Assembly  # type: ignore
+    from pyadomd import Pyadomd  # type: ignore
+except Exception:  # pragma: no cover - import errors
+    clr = None
+    Assembly = None
+    Pyadomd = None
+
+# Default connection string matching the example
+CONN_STR = (
+    "Provider=MSOLAP;"
+    "Data Source=server;"
+    "Initial Catalog=Cube8;"
+    "Integrated Security=SSPI;"
+)
+
+def get_conn_str() -> str:
+    """Return configured connection string or the default example."""
+    return settings.adomd_conn_str or CONN_STR
+
+def open_connection():
+    """Return a Pyadomd connection object using the configured settings."""
+    if Pyadomd is None or clr is None:
+        raise RuntimeError("pyadomd library not installed")
+    if settings.adomd_dll_path:
+        os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
+        Assembly.LoadFrom(settings.adomd_dll_path)
+    return Pyadomd(get_conn_str())

--- a/backend/app/list_measures.py
+++ b/backend/app/list_measures.py
@@ -1,0 +1,32 @@
+import os
+from .connection import open_connection
+
+SQL = """
+SELECT
+    MEASURE_NAME
+FROM
+    $SYSTEM.MDSCHEMA_MEASURES
+WHERE
+    CUBE_NAME = '{cube}'
+ORDER BY
+    MEASURE_NAME
+"""
+
+
+def main() -> None:
+    cube = os.environ.get("CUBE_NAME", "")
+    if not cube:
+        raise SystemExit("CUBE_NAME environment variable not set")
+
+    sql = SQL.format(cube=cube)
+    with open_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            measures = [row[0] for row in cur.fetchall()]
+
+    for m in measures:
+        print(m)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/routers/fields.py
+++ b/backend/app/routers/fields.py
@@ -1,41 +1,21 @@
 from fastapi import APIRouter, HTTPException
-from ..config import settings
-import os
-
-try:
-    import clr  # type: ignore
-    from System.Reflection import Assembly  # type: ignore
-    from pyadomd import Pyadomd  # type: ignore
-except Exception:  # pragma: no cover - import errors
-    clr = None
-    Assembly = None
-    Pyadomd = None
+from ..connection import open_connection
 
 router = APIRouter(prefix="/fields", tags=["fields"])
 
+
 @router.get("")
 def list_fields():
-    if Pyadomd is None or clr is None:
-        return {"dimensions": [], "measures": []}
-
-    if not settings.adomd_conn_str:
-        raise HTTPException(status_code=500, detail="ADOMD_CONN_STR not configured")
-
     try:
-        if settings.adomd_dll_path:
-            os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
-            Assembly.LoadFrom(settings.adomd_dll_path)
-
-        with Pyadomd(settings.adomd_conn_str) as conn:
+        with open_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT DIMENSION_NAME FROM $SYSTEM.MDSCHEMA_DIMENSIONS")
                 dimensions = [row[0] for row in cur.fetchall()]
 
-        with Pyadomd(settings.adomd_conn_str) as conn:
+        with open_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT MEASURE_NAME FROM $SYSTEM.MDSCHEMA_MEASURES")
                 measures = [row[0] for row in cur.fetchall()]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-
     return {"dimensions": dimensions, "measures": measures}

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,15 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from ..config import settings
-import os
-
-try:
-    import clr  # type: ignore
-    from System.Reflection import Assembly  # type: ignore
-    from pyadomd import Pyadomd  # type: ignore
-except Exception:  # pragma: no cover - import errors
-    clr = None
-    Assembly = None
-    Pyadomd = None
+from ..connection import open_connection
 
 router = APIRouter(prefix="/health", tags=["health"])
 
@@ -17,21 +7,13 @@ router = APIRouter(prefix="/health", tags=["health"])
 @router.get("")
 def health_check():
     """Simple health check ensuring connection to the cube works."""
-    if Pyadomd is None or clr is None:
-        raise HTTPException(status_code=500, detail="pyadomd library not installed")
-
-    if not settings.adomd_conn_str:
-        raise HTTPException(status_code=500, detail="ADOMD_CONN_STR not configured")
-
     try:
-        if settings.adomd_dll_path:
-            os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
-            Assembly.LoadFrom(settings.adomd_dll_path)
-
-        with Pyadomd(settings.adomd_conn_str) as conn:
+        with open_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT CATALOG_NAME FROM $SYSTEM.MDSCHEMA_CUBES")
                 cur.fetchone()
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Connection failed: {e}")
     return {"status": "ok"}

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -1,34 +1,14 @@
 from fastapi import APIRouter, HTTPException
-import os
 from ..schemas import QueryRequest, QueryResponse
-from ..config import settings
-
-try:
-    import clr  # type: ignore
-    from System.Reflection import Assembly  # type: ignore
-    from pyadomd import Pyadomd  # type: ignore
-except Exception:  # pragma: no cover - import errors
-    clr = None
-    Assembly = None
-    Pyadomd = None
+from ..connection import open_connection
 
 router = APIRouter(prefix="/query", tags=["query"])
 
 
 @router.post("", response_model=QueryResponse)
 def run_query(req: QueryRequest):
-    if Pyadomd is None or clr is None:
-        raise HTTPException(status_code=500, detail="pyadomd library not installed")
-
-    if not settings.adomd_conn_str:
-        raise HTTPException(status_code=500, detail="ADOMD_CONN_STR not configured")
-
     try:
-        if settings.adomd_dll_path:
-            os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
-            Assembly.LoadFrom(settings.adomd_dll_path)
-
-        with Pyadomd(settings.adomd_conn_str) as conn:
+        with open_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(req.mdx)
                 columns = [d[0] for d in cur.description]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from backend.app.main import app
+from backend.app import connection
 from backend.app.routers import health
 
 
@@ -40,9 +41,10 @@ class DummyPyadomd:
 
 
 def test_health_success(monkeypatch):
-    monkeypatch.setattr(health, "Pyadomd", DummyPyadomd)
-    monkeypatch.setattr(health, "clr", object())
-    monkeypatch.setattr(health.settings, "adomd_conn_str", "cs")
+    monkeypatch.setattr(connection, "Pyadomd", DummyPyadomd)
+    monkeypatch.setattr(connection, "clr", object())
+    monkeypatch.setattr(connection.settings, "adomd_conn_str", "cs")
+    monkeypatch.setattr(connection.settings, "adomd_dll_path", "")
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 200
@@ -50,7 +52,7 @@ def test_health_success(monkeypatch):
 
 
 def test_health_no_provider(monkeypatch):
-    monkeypatch.setattr(health, "Pyadomd", None)
+    monkeypatch.setattr(connection, "Pyadomd", None)
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- centralize cube connection logic in `connection.py`
- simplify routers and helper script to use the shared connection
- health check now catches connection errors properly
- note default connection string example in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688696b948108322a2ec21000e923c31