### PR TITLE
Use single Pyadomd connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Build and start the backend using Docker Compose:
 docker compose up --build
 ```
 
-The backend will be available at `http://localhost:8000`. Endpoints:
+The backend will be available at `http://localhost:8000`. On startup the
+application opens a single connection to the cube using the same settings as in
+the manual example. Endpoints reuse this connection.
+
+Endpoints:
 
 - `POST /query` – run an MDX query ({"mdx": "..."})
 - `GET /fields` – list available cube dimensions and measures
@@ -96,3 +100,10 @@ Use the helper script to print all measures from a cube. Set `CUBE_NAME` and con
 ```bash
 CUBE_NAME=NextGen python -m backend.app.list_measures
 ```
+
+## Example: manual connection
+
+For a minimal example mirroring the basic ADOMD.NET setup, see
+`backend/app/examples/manual_connection.py`. It shows how to load the
+`Microsoft.AnalysisServices.AdomdClient.dll` assembly, create a connection with
+`Pyadomd`, and execute a query against the cube.

--- a/backend/app/examples/manual_connection.py
+++ b/backend/app/examples/manual_connection.py
@@ -1,0 +1,36 @@
+import os
+import clr
+from System.Reflection import Assembly
+from pyadomd import Pyadomd
+
+# Path to ADOMD.NET DLL
+DLL_PATH = r"C:\Program Files\Microsoft.NET\ADOMD.NET\110\Microsoft.AnalysisServices.AdomdClient.dll"
+
+# Add folder to DLL search path and load the assembly
+os.add_dll_directory(os.path.dirname(DLL_PATH))
+Assembly.LoadFrom(DLL_PATH)
+
+# Connection string for the cube
+CONN_STR = (
+    "Provider=MSOLAP;"
+    "Data Source=server;"
+    "Initial Catalog=Cube8;"
+    "Integrated Security=SSPI;"
+)
+
+SQL = """
+SELECT
+    MEASURE_NAME
+FROM
+    $SYSTEM.MDSCHEMA_MEASURES
+WHERE
+    CUBE_NAME = 'NextGen'
+ORDER BY
+    MEASURE_NAME
+"""
+
+# Execute a query using pyadomd
+with Pyadomd(CONN_STR) as conn:
+    with conn.cursor() as cur:
+        cur.execute(SQL)
+        print([row[0] for row in cur.fetchall()])

--- a/backend/app/list_measures.py
+++ b/backend/app/list_measures.py
@@ -19,10 +19,10 @@ def main() -> None:
         raise SystemExit("CUBE_NAME environment variable not set")
 
     sql = SQL.format(cube=cube)
-    with open_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(sql)
-            measures = [row[0] for row in cur.fetchall()]
+    conn = open_connection()
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        measures = [row[0] for row in cur.fetchall()]
 
     for m in measures:
         print(m)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,24 @@
 from fastapi import FastAPI
 
 from .routers import query, reports, fields, health
+from .connection import open_connection, close_connection
 
 app = FastAPI(title="Cube Visual")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    """Establish the cube connection on startup."""
+    try:
+        open_connection()
+    except Exception:
+        # connection errors will surface when endpoints are called
+        pass
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    close_connection()
 
 app.include_router(query.router)
 app.include_router(reports.router)

--- a/backend/app/routers/fields.py
+++ b/backend/app/routers/fields.py
@@ -7,15 +7,14 @@ router = APIRouter(prefix="/fields", tags=["fields"])
 @router.get("")
 def list_fields():
     try:
-        with open_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT DIMENSION_NAME FROM $SYSTEM.MDSCHEMA_DIMENSIONS")
-                dimensions = [row[0] for row in cur.fetchall()]
+        conn = open_connection()
+        with conn.cursor() as cur:
+            cur.execute("SELECT DIMENSION_NAME FROM $SYSTEM.MDSCHEMA_DIMENSIONS")
+            dimensions = [row[0] for row in cur.fetchall()]
 
-        with open_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT MEASURE_NAME FROM $SYSTEM.MDSCHEMA_MEASURES")
-                measures = [row[0] for row in cur.fetchall()]
+        with conn.cursor() as cur:
+            cur.execute("SELECT MEASURE_NAME FROM $SYSTEM.MDSCHEMA_MEASURES")
+            measures = [row[0] for row in cur.fetchall()]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {"dimensions": dimensions, "measures": measures}

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -8,10 +8,10 @@ router = APIRouter(prefix="/health", tags=["health"])
 def health_check():
     """Simple health check ensuring connection to the cube works."""
     try:
-        with open_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT CATALOG_NAME FROM $SYSTEM.MDSCHEMA_CUBES")
-                cur.fetchone()
+        conn = open_connection()
+        with conn.cursor() as cur:
+            cur.execute("SELECT CATALOG_NAME FROM $SYSTEM.MDSCHEMA_CUBES")
+            cur.fetchone()
     except RuntimeError as e:
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -8,11 +8,11 @@ router = APIRouter(prefix="/query", tags=["query"])
 @router.post("", response_model=QueryResponse)
 def run_query(req: QueryRequest):
     try:
-        with open_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(req.mdx)
-                columns = [d[0] for d in cur.description]
-                rows = cur.fetchall()
+        conn = open_connection()
+        with conn.cursor() as cur:
+            cur.execute(req.mdx)
+            columns = [d[0] for d in cur.description]
+            rows = cur.fetchall()
         data = [dict(zip(columns, r)) for r in rows]
         return QueryResponse(columns=columns, data=data)
     except Exception as e:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -33,11 +33,14 @@ class DummyPyadomd:
     def __init__(self, conn_str):
         self.conn_str = conn_str
 
-    def __enter__(self):
-        return DummyConn()
-
-    def __exit__(self, exc_type, exc, tb):
+    def open(self):
         pass
+
+    def close(self):
+        pass
+
+    def cursor(self):
+        return DummyCursor()
 
 
 def test_health_success(monkeypatch):
@@ -45,6 +48,7 @@ def test_health_success(monkeypatch):
     monkeypatch.setattr(connection, "clr", object())
     monkeypatch.setattr(connection.settings, "adomd_conn_str", "cs")
     monkeypatch.setattr(connection.settings, "adomd_dll_path", "")
+    connection._conn = None
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 200
@@ -53,6 +57,7 @@ def test_health_success(monkeypatch):
 
 def test_health_no_provider(monkeypatch):
     monkeypatch.setattr(connection, "Pyadomd", None)
+    connection._conn = None
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- keep a singleton cube connection
- reuse that connection for all routes and list_measures script
- initialize and close the connection on app startup/shutdown
- update health tests
- note connection reuse in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869c0c50448322b10e14410cbddb4e