### PR TITLE
Implement manual connection defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ and uses **pyadomd** (ADOMD.NET) to query the cube. The frontend is built with
   variable so pythonnet loads the CoreCLR runtime.
 - Access to an OLAP cube. Create a `.env` file inside `backend` with connection
   details for your cube (see `backend/.env.example`). The main settings are
-  `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`. If `ADOMD_CONN_STR` is not provided the
-  example connection string
+  `ADOMD_DLL_PATH` and `ADOMD_CONN_STR`. If these variables are not provided the
+  example DLL path and connection string
 
   ```python
   conn_str = (
@@ -27,7 +27,7 @@ and uses **pyadomd** (ADOMD.NET) to query the cube. The frontend is built with
   )
   ```
 
-  will be used.
+  will be used by default.
 
 ## Running the backend
 

--- a/backend/app/connection.py
+++ b/backend/app/connection.py
@@ -18,6 +18,14 @@ CONN_STR = (
     "Integrated Security=SSPI;"
 )
 
+# Default DLL path matching the manual example
+DLL_PATH = r"C:\\Program Files\\Microsoft.NET\\ADOMD.NET\\110\\Microsoft.AnalysisServices.AdomdClient.dll"
+
+
+def get_dll_path() -> str:
+    """Return configured DLL path or the default example."""
+    return settings.adomd_dll_path or DLL_PATH
+
 def get_conn_str() -> str:
     """Return configured connection string or the default example."""
     return settings.adomd_conn_str or CONN_STR
@@ -35,9 +43,10 @@ def open_connection():
     if _conn is not None:
         return _conn
 
-    if settings.adomd_dll_path:
-        os.add_dll_directory(os.path.dirname(settings.adomd_dll_path))
-        Assembly.LoadFrom(settings.adomd_dll_path)
+    dll_path = get_dll_path()
+    if dll_path:
+        os.add_dll_directory(os.path.dirname(dll_path))
+        Assembly.LoadFrom(dll_path)
 
     _conn = Pyadomd(get_conn_str())
     _conn.open()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -46,8 +46,11 @@ class DummyPyadomd:
 def test_health_success(monkeypatch):
     monkeypatch.setattr(connection, "Pyadomd", DummyPyadomd)
     monkeypatch.setattr(connection, "clr", object())
+    monkeypatch.setattr(connection.os, "add_dll_directory", lambda p: None, raising=False)
+    monkeypatch.setattr(connection, "Assembly", type("A", (), {"LoadFrom": lambda self, p: None})())
     monkeypatch.setattr(connection.settings, "adomd_conn_str", "cs")
     monkeypatch.setattr(connection.settings, "adomd_dll_path", "")
+    monkeypatch.setattr(connection, "DLL_PATH", "dummy.dll")
     connection._conn = None
     client = TestClient(app)
     resp = client.get("/health")


### PR DESCRIPTION
## Summary
- use manual connection defaults for DLL path and connection string
- document default connection settings in README
- update health check tests for new logic

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a0fcbcdc8322913653b27757de09