### PR TITLE
Fix env loading and CORS parsing

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,10 +2,36 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List
 import os
 
+# Determine which environment file to load. By default we try ``.env``. If it
+# does not exist fall back to ``.env.example`` so the application can start
+# with the sample configuration. Users can still override values using real
+# environment variables or by creating their own ``.env`` file.
+_env_file = os.path.join(os.path.dirname(__file__), "..", ".env")
+if not os.path.exists(_env_file):
+    example_file = os.path.join(os.path.dirname(__file__), "..", ".env.example")
+    if os.path.exists(example_file):
+        _env_file = example_file
+
 class Settings(BaseSettings):
     adomd_connection: str
     adomd_dll_path: str | None = None
-    cors_origins: List[str] = ["*"]
-    model_config = SettingsConfigDict(env_file=os.path.join(os.path.dirname(__file__), "..", ".env"), env_file_encoding="utf-8", extra="ignore")
+    cors_origins: str = "*"
+
+    @property
+    def cors_origins_list(self) -> List[str]:
+        """Return CORS origins as a list."""
+        v = self.cors_origins.strip()
+        if not v:
+            return []
+        if v.startswith("["):
+            import json
+            try:
+                return json.loads(v)
+            except Exception:
+                pass
+        return [item.strip() for item in v.split(",") if item.strip()]
+        
+
+    model_config = SettingsConfigDict(env_file=_env_file, env_file_encoding="utf-8", extra="ignore")
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,12 @@ from .config import settings
 from .routers import schema, query
 
 app = FastAPI(title="OLAP Explorer")
-app.add_middleware(CORSMiddleware, allow_origins=settings.cors_origins, allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(schema.router)
 app.include_router(query.router)


### PR DESCRIPTION
## Summary
- load configuration from `.env` or `.env.example`
- allow comma-separated CORS configuration via `cors_origins_list`

## Testing
- `pip install -r backend/requirements.txt`
- `uvicorn backend.app.main:app --port 8001 --lifespan off` *(fails: Could not find libmono)*

------
https://chatgpt.com/codex/tasks/task_e_6886ad19c53483229fc457f573b9b941