### PR TITLE
Add default query sample

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pyadomd==0.1.0
 pythonnet==3.0.3
 pydantic==2.9.2
 pydantic-settings==2.6.1
+httpx==0.27.0

--- a/frontend/src/components/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder.tsx
@@ -6,7 +6,10 @@ import MeasureSelector from './MeasureSelector'
 import DimensionTree from './DimensionTree'
 
 type Props = { onResult: (r: QueryRunResponse) => void }
-const DEFAULT_MDX = 'SELECT TABLE_CATALOG FROM $SYSTEM.DBSCHEMA_CATALOGS'
+const DEFAULT_MDX = `SELECT
+  NON EMPTY [Концерн].[Концерн].Members ON ROWS,
+  { [Measures].[реализация руб] } ON COLUMNS
+FROM [NextGen]`
 
 export default function QueryBuilder({ onResult }: Props) {
   const [cubes, setCubes] = useState<Cube[]>([])


### PR DESCRIPTION
## Summary
- show a sample cube query by default
- include `httpx` dependency for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891711e768832297f839b5c1de6311