### PR TITLE
Set default query & auto chart

### DIFF
--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -5,9 +5,22 @@ from ..adomd import fetch
 from ..mdx_builder import build_mdx
 
 DEFAULT_MDX = (
+    "WITH\n"
+    "SET [Months2024] AS\n"
+    "  NonEmpty(\n"
+    "    Descendants(\n"
+    "      [Время].[Год - Квартал - Месяц - День].&[2024],\n"
+    "      [Время].[Год - Квартал - Месяц - День].[Месяц]\n"
+    "    ),\n"
+    "    { [Measures].[реализация руб] }\n"
+    "  )\n"
     "SELECT\n"
-    "  NON EMPTY [Концерн].[Концерн].Members ON ROWS,\n"
-    "  { [Measures].[реализация руб] } ON COLUMNS\n"
+    "  NON EMPTY\n"
+    "    [Months2024] * { [Measures].[реализация руб] }\n"
+    "  ON COLUMNS,\n"
+    "  NON EMPTY\n"
+    "    [Товар].[Концерн].Members\n"
+    "  ON ROWS\n"
     "FROM [NextGen]"
 )
 

--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { Box, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from '@mui/material'
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, BarChart, Bar } from 'recharts'
 import { QueryRunResponse } from '../types'
@@ -7,6 +7,16 @@ type Props = { result: QueryRunResponse | null }
 export default function ChartView({ result }: Props) {
   const [xField, setXField] = useState<string>('')
   const [yField, setYField] = useState<string>('')
+
+  useEffect(() => {
+    if (!result || result.columns.length < 2) {
+      setXField('')
+      setYField('')
+      return
+    }
+    setXField(result.columns[0])
+    setYField(result.columns[1])
+  }, [result])
 
   const options = result?.columns || []
   const data = useMemo(() => {
@@ -37,19 +47,19 @@ export default function ChartView({ result }: Props) {
       </Stack>
       {data.length > 0 && xField && yField && (
         <Stack gap={4}>
-          <LineChart width={960} height={360} data={data}>
+          <LineChart width={960} height={360} data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey={xField} />
             <YAxis />
             <Tooltip />
-            <Line type="monotone" dataKey={yField} />
+            <Line type="monotone" dataKey={yField} stroke="#1976d2" strokeWidth={2} />
           </LineChart>
-          <BarChart width={960} height={360} data={data}>
+          <BarChart width={960} height={360} data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey={xField} />
             <YAxis />
             <Tooltip />
-            <Bar dataKey={yField} />
+            <Bar dataKey={yField} fill="#1976d2" fillOpacity={0.7} />
           </BarChart>
         </Stack>
       )}

--- a/frontend/src/components/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder.tsx
@@ -6,9 +6,22 @@ import MeasureSelector from './MeasureSelector'
 import DimensionTree from './DimensionTree'
 
 type Props = { onResult: (r: QueryRunResponse) => void }
-const DEFAULT_MDX = `SELECT
-  NON EMPTY [Концерн].[Концерн].Members ON ROWS,
-  { [Measures].[реализация руб] } ON COLUMNS
+const DEFAULT_MDX = `WITH
+SET [Months2024] AS
+  NonEmpty(
+    Descendants(
+      [Время].[Год - Квартал - Месяц - День].&[2024],
+      [Время].[Год - Квартал - Месяц - День].[Месяц]
+    ),
+    { [Measures].[реализация руб] }
+  )
+SELECT
+  NON EMPTY
+    [Months2024] * { [Measures].[реализация руб] }
+  ON COLUMNS,
+  NON EMPTY
+    [Товар].[Концерн].Members
+  ON ROWS
 FROM [NextGen]`
 
 export default function QueryBuilder({ onResult }: Props) {


### PR DESCRIPTION
## Summary
- set a new default MDX query showing 2024 months per concern
- auto-select axes and style ChartView

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68892a6f82f483229a86a599c8bba46d