### PR TITLE
Update default MDX query and chart labels

### DIFF
--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -5,18 +5,10 @@ from ..adomd import fetch
 from ..mdx_builder import build_mdx
 
 DEFAULT_MDX = (
-    "WITH\n"
-    "SET [Months2024] AS\n"
-    "  NonEmpty(\n"
-    "    Descendants(\n"
-    "      [Время].[Год - Квартал - Месяц - День].&[2024],\n"
-    "      [Время].[Год - Квартал - Месяц - День].[Месяц]\n"
-    "    ),\n"
-    "    { [Measures].[реализация руб] }\n"
-    "  )\n"
     "SELECT\n"
     "  NON EMPTY\n"
-    "    [Months2024] * { [Measures].[реализация руб] }\n"
+    "    [Время].[Год - Квартал - Месяц - День].&[2024].Children\n"
+    "    * { [Measures].[реализация руб] }\n"
     "  ON COLUMNS,\n"
     "  NON EMPTY\n"
     "    [Товар].[Концерн].Members\n"

--- a/frontend/src/components/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder.tsx
@@ -8,18 +8,10 @@ import DimensionTree from './DimensionTree'
 type Props = { onResult: (r: QueryRunResponse) => void }
 
 const EXAMPLE_QUERIES: Record<string, string> = {
-  matrix: `WITH
-SET [Months2024] AS
-  NonEmpty(
-    Descendants(
-      [Время].[Год - Квартал - Месяц - День].&[2024],
-      [Время].[Год - Квартал - Месяц - День].[Месяц]
-    ),
-    { [Measures].[реализация руб] }
-  )
-SELECT
+  matrix: `SELECT
   NON EMPTY
-    [Months2024] * { [Measures].[реализация руб] }
+    [Время].[Год - Квартал - Месяц - День].&[2024].Children
+    * { [Measures].[реализация руб] }
   ON COLUMNS,
   NON EMPTY
     [Товар].[Концерн].Members


### PR DESCRIPTION
## Summary
- change default MDX query to show 2024 month children
- display measure name in chart instead of generic `value`
- parse numbers more robustly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893fa0f6cc8322bc4a9b27c0a641be