### PR TITLE
Improve total row removal

### DIFF
--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -30,3 +30,17 @@ def test_strip_total_row(monkeypatch, client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["rows"] == [["A", 10], ["B", 20]]
+
+
+def test_strip_total_row_last(monkeypatch, client):
+    cols = ["name", "value"]
+    rows = [["A", 10], ["B", 20], ["All", 30]]
+
+    def fake_fetch(mdx: str):
+        return cols, rows
+
+    monkeypatch.setattr("app.routers.query.fetch", fake_fetch)
+    resp = client.post("/query/run", json={"mdx": "SELECT"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rows"] == [["A", 10], ["B", 20]]


### PR DESCRIPTION
## Summary
- enhance `_strip_total_row` to remove a totals row at the start or end of results
- test both first and last row removal cases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889433660a48322af4424739c287b1e