### PR TITLE
Filter empty concern row

### DIFF
--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -48,6 +48,19 @@ def _strip_total_row(columns: List[str], rows: List[List[Any]]) -> List[List[Any
         return rows[:-1]
     return rows
 
+
+def _remove_empty_first_value(rows: List[List[Any]]) -> List[List[Any]]:
+    """Drop rows whose first cell is empty."""
+    out = []
+    for r in rows:
+        if not r:
+            continue
+        first = str(r[0]).strip() if r[0] is not None else ""
+        if first == "":
+            continue
+        out.append(r)
+    return out
+
 DEFAULT_MDX = (
     "SELECT\n"
     "  NON EMPTY\n"
@@ -80,6 +93,7 @@ def run(req: RunRequest):
         mdx = DEFAULT_MDX
     cols, rows = fetch(mdx)
     rows = _strip_total_row(cols, rows)
+    rows = _remove_empty_first_value(rows)
     return {"mdx": mdx, "columns": cols, "rows": rows}
 
 @router.get("/health")

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -44,3 +44,17 @@ def test_strip_total_row_last(monkeypatch, client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["rows"] == [["A", 10], ["B", 20]]
+
+
+def test_remove_empty_first_cell(monkeypatch, client):
+    cols = ["concern", "value"]
+    rows = [["", 5], ["A", 10], ["B", 20]]
+
+    def fake_fetch(mdx: str):
+        return cols, rows
+
+    monkeypatch.setattr("app.routers.query.fetch", fake_fetch)
+    resp = client.post("/query/run", json={"mdx": "SELECT"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rows"] == [["A", 10], ["B", 20]]


### PR DESCRIPTION
## Summary
- drop rows with empty values in the first column
- add unit test for removing empty concern rows

## Testing
- `pip install -q -r requirements.txt && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894449e2908322a9c60c5e1ac25009